### PR TITLE
feat: add Projects feature with system prompt support

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { useLocalStorage } from "@/lib/useLocalStorage";
 import { mergeModels, useCustomModels } from "@/lib/customModels";
 import { ChatMessage, ApiKeys, ChatThread } from "@/lib/types";
 import { createChatActions } from "@/lib/chatActions";
+import { useProjects } from "@/lib/useProjects";
 import ModelsModal from "@/components/ModelsModal";
 import FirstVisitNote from "@/components/FirstVisitNote";
 import FixedInputBar from "@/components/FixedInputBar";
@@ -48,6 +49,17 @@ export default function Home() {
   const [modelsModalOpen, setModelsModalOpen] = useState(false);
   const [customModels] = useCustomModels();
   const allModels = useMemo(() => mergeModels(customModels), [customModels]);
+  
+  // Projects hook
+  const {
+    projects,
+    activeProjectId,
+    activeProject,
+    createProject,
+    updateProject,
+    deleteProject,
+    selectProject,
+  } = useProjects();
   const activeThread = useMemo(
     () => threads.find((t) => t.id === activeId) || null,
     [threads, activeId]
@@ -119,8 +131,9 @@ export default function Home() {
         setActiveId,
         setLoadingIds: (updater) => setLoadingIds(updater),
         setLoadingIdsInit: (ids) => setLoadingIds(ids),
+        activeProject, // Add active project for system prompt
       }),
-    [selectedModels, keys, threads, activeThread, setThreads, setActiveId]
+    [selectedModels, keys, threads, activeThread, setThreads, setActiveId, activeProject]
   );
 
   // group assistant messages by turn for simple compare view
@@ -175,6 +188,12 @@ export default function Home() {
                 return next;
               });
             }}
+            projects={projects}
+            activeProjectId={activeProjectId}
+            onSelectProject={selectProject}
+            onCreateProject={createProject}
+            onUpdateProject={updateProject}
+            onDeleteProject={deleteProject}
           />
           {/* Main content */}
           <div className="flex-1 min-w-0 flex flex-col h-[calc(100vh-2rem)] lg:h-[calc(100vh-3rem)] overflow-hidden">

--- a/components/ProjectModal.tsx
+++ b/components/ProjectModal.tsx
@@ -1,0 +1,189 @@
+"use client";
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+import { Project, createProject, updateProject, validateProjectName, validateSystemPrompt } from "@/lib/projects";
+
+interface ProjectModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (project: Project) => void;
+  project?: Project | null; // null for create, Project for edit
+}
+
+export default function ProjectModal({
+  open,
+  onClose,
+  onSave,
+  project = null,
+}: ProjectModalProps) {
+  const [name, setName] = useState("");
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [promptError, setPromptError] = useState<string | null>(null);
+
+  const isEditing = project !== null;
+  const title = isEditing ? "Edit project" : "Create new project";
+  const buttonText = isEditing ? "Save changes" : "Create project";
+
+  // Reset form when modal opens/closes or project changes
+  useEffect(() => {
+    if (open) {
+      if (project) {
+        setName(project.name);
+        setSystemPrompt(project.systemPrompt);
+      } else {
+        setName("");
+        setSystemPrompt("");
+      }
+      setNameError(null);
+      setPromptError(null);
+    }
+  }, [open, project]);
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    setNameError(null);
+  };
+
+  const handlePromptChange = (value: string) => {
+    setSystemPrompt(value);
+    setPromptError(null);
+  };
+
+  const handleSubmit = () => {
+    // Validate inputs
+    const nameValidation = validateProjectName(name);
+    const promptValidation = validateSystemPrompt(systemPrompt);
+
+    setNameError(nameValidation);
+    setPromptError(promptValidation);
+
+    if (nameValidation || promptValidation) {
+      return;
+    }
+
+    // Create or update project
+    let savedProject: Project;
+    if (isEditing && project) {
+      savedProject = updateProject(project, { name, systemPrompt });
+    } else {
+      savedProject = createProject(name, systemPrompt);
+    }
+
+    onSave(savedProject);
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onClose();
+    } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      handleSubmit();
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div 
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm" 
+        onClick={onClose}
+      />
+      
+      {/* Modal */}
+      <div 
+        className="relative w-full max-w-md bg-zinc-900/95 border border-white/20 rounded-lg shadow-2xl"
+        onKeyDown={handleKeyDown}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-white/10">
+          <h2 className="text-lg font-semibold text-white">{title}</h2>
+          <button
+            onClick={onClose}
+            className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-white/10 text-white/60 hover:text-white transition-colors"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-4 space-y-4">
+          <p className="text-sm text-white/70">
+            Fill in the details below to {isEditing ? 'update' : 'create'} {isEditing ? 'this' : 'a new'} project.
+          </p>
+
+          {/* Project Name */}
+          <div>
+            <label htmlFor="project-name" className="block text-sm font-medium text-white/80 mb-2">
+              Project name
+            </label>
+            <input
+              id="project-name"
+              type="text"
+              value={name}
+              onChange={(e) => handleNameChange(e.target.value)}
+              placeholder="Enter a name for your project (max 50 characters)"
+              className={`w-full px-3 py-2 bg-white/5 border rounded-md text-white placeholder-white/40 focus:outline-none focus:ring-2 transition-colors ${
+                nameError 
+                  ? 'border-red-400 focus:ring-red-400/50' 
+                  : 'border-white/20 focus:border-white/30 focus:ring-[var(--accent-interactive-primary)]/50'
+              }`}
+              maxLength={50}
+              autoFocus
+            />
+            {nameError && (
+              <p className="mt-1 text-xs text-red-400">{nameError}</p>
+            )}
+            <p className="mt-1 text-xs text-white/50">{name.length}/50 characters</p>
+          </div>
+
+          {/* System Prompt */}
+          <div>
+            <label htmlFor="system-prompt" className="block text-sm font-medium text-white/80 mb-2">
+              System prompt
+            </label>
+            <textarea
+              id="system-prompt"
+              value={systemPrompt}
+              onChange={(e) => handlePromptChange(e.target.value)}
+              placeholder="Enter a system prompt for chats in this project (max 1000 characters)"
+              rows={6}
+              className={`w-full px-3 py-2 bg-white/5 border rounded-md text-white placeholder-white/40 resize-none focus:outline-none focus:ring-2 transition-colors ${
+                promptError 
+                  ? 'border-red-400 focus:ring-red-400/50' 
+                  : 'border-white/20 focus:border-white/30 focus:ring-[var(--accent-interactive-primary)]/50'
+              }`}
+              maxLength={1000}
+            />
+            {promptError && (
+              <p className="mt-1 text-xs text-red-400">{promptError}</p>
+            )}
+            <div className="mt-1 flex justify-between text-xs text-white/50">
+              <span>All chats in this project will use this as the system prompt sent to the AI model.</span>
+              <span>{systemPrompt.length}/1000</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 p-4 border-t border-white/10">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm rounded-md border border-white/20 bg-white/5 hover:bg-white/10 text-white transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            className="px-4 py-2 text-sm rounded-md text-white shadow transition-colors accent-action-fill accent-focus"
+          >
+            {buttonText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ProjectsSection.tsx
+++ b/components/ProjectsSection.tsx
@@ -1,0 +1,234 @@
+"use client";
+import { useState } from "react";
+import { Plus, Settings, Trash2 } from "lucide-react";
+import { Project } from "@/lib/projects";
+import ProjectModal from "@/components/ProjectModal";
+import ConfirmDialog from "@/components/ConfirmDialog";
+
+interface ProjectsSectionProps {
+  projects: Project[];
+  activeProjectId: string | null;
+  onSelectProject: (id: string | null) => void;
+  onCreateProject: (project: Project) => void;
+  onUpdateProject: (project: Project) => void;
+  onDeleteProject: (id: string) => void;
+  collapsed: boolean;
+}
+
+export default function ProjectsSection({
+  projects,
+  activeProjectId,
+  onSelectProject,
+  onCreateProject,
+  onUpdateProject,
+  onDeleteProject,
+  collapsed,
+}: ProjectsSectionProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingProject, setEditingProject] = useState<Project | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const handleCreateNew = () => {
+    setEditingProject(null);
+    setModalOpen(true);
+  };
+
+  const handleEdit = (project: Project) => {
+    setEditingProject(project);
+    setModalOpen(true);
+  };
+
+  const handleSave = (project: Project) => {
+    if (editingProject) {
+      onUpdateProject(project);
+    } else {
+      onCreateProject(project);
+    }
+    setEditingProject(null);
+  };
+
+  const handleDelete = (id: string) => {
+    setConfirmDeleteId(id);
+  };
+
+  const confirmDelete = () => {
+    if (confirmDeleteId) {
+      onDeleteProject(confirmDeleteId);
+      // If we're deleting the active project, deselect it
+      if (confirmDeleteId === activeProjectId) {
+        onSelectProject(null);
+      }
+    }
+    setConfirmDeleteId(null);
+  };
+
+  if (collapsed) {
+    return (
+      <>
+        {/* Collapsed view */}
+        <div className="flex flex-col items-center gap-2 pt-2">
+          {/* Add project button */}
+          <button
+            title="New Project"
+            onClick={handleCreateNew}
+            className="h-8 w-8 rounded-full flex items-center justify-center text-white transition-colors accent-action-fill accent-focus"
+          >
+            <Plus size={14} />
+          </button>
+
+          {/* Project indicators */}
+          {projects.map((project) => {
+            const isActive = project.id === activeProjectId;
+            const initial = project.name.trim()[0]?.toUpperCase() || 'P';
+            return (
+              <button
+                key={project.id}
+                title={project.name}
+                onClick={() => onSelectProject(project.id)}
+                className={`h-6 w-6 rounded-full flex items-center justify-center transition-colors focus-visible:outline-none 
+                  ${
+                    isActive
+                      ? "bg-[var(--accent-interactive-primary)] ring-1 ring-[var(--accent-interactive-hover)] ring-offset-1 ring-offset-black text-white"
+                      : "bg-white/10 hover:bg-white/20 text-white/70 hover:text-white"
+                  }`}
+              >
+                <span className="text-[10px] font-semibold leading-none">
+                  {initial}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <ProjectModal
+          open={modalOpen}
+          onClose={() => setModalOpen(false)}
+          onSave={handleSave}
+          project={editingProject}
+        />
+
+        <ConfirmDialog
+          open={!!confirmDeleteId}
+          title="Delete project?"
+          message="This will permanently delete the project and cannot be undone."
+          confirmText="Delete"
+          cancelText="Cancel"
+          onCancel={() => setConfirmDeleteId(null)}
+          onConfirm={confirmDelete}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      {/* Expanded view */}
+      <div className="space-y-2">
+        {/* Header with add button */}
+        <div className="flex items-center justify-between">
+          <div className="text-xs uppercase tracking-wide opacity-60">
+            Projects
+          </div>
+          <button
+            title="New Project"
+            onClick={handleCreateNew}
+            className="h-6 w-6 rounded-full flex items-center justify-center text-white/60 hover:text-white hover:bg-white/10 transition-colors"
+          >
+            <Plus size={12} />
+          </button>
+        </div>
+
+        {/* No projects message */}
+        {projects.length === 0 && (
+          <div className="text-xs opacity-60 py-2">No projects yet</div>
+        )}
+
+        {/* None/Default option */}
+        <div
+          className={`w-full px-2 py-2 rounded-md text-sm border flex items-center justify-between gap-2 group cursor-pointer ${
+            activeProjectId === null
+              ? "bg-white/15 border-white/20"
+              : "bg-white/5 border-white/10 hover:bg-white/10"
+          }`}
+          onClick={() => onSelectProject(null)}
+        >
+          <div className="min-w-0 text-left flex-1">
+            <div className="truncate font-medium">No Project</div>
+            <div className="text-xs opacity-60 truncate">Default system behavior</div>
+          </div>
+        </div>
+
+        {/* Project list */}
+        {projects.map((project) => {
+          const isActive = project.id === activeProjectId;
+          return (
+            <div
+              key={project.id}
+              className={`w-full px-2 py-2 rounded-md text-sm border flex items-center justify-between gap-2 group ${
+                isActive
+                  ? "bg-white/15 border-white/20"
+                  : "bg-white/5 border-white/10 hover:bg-white/10"
+              }`}
+            >
+              <button
+                onClick={() => onSelectProject(project.id)}
+                className="min-w-0 text-left flex-1"
+                title={`${project.name}${project.systemPrompt ? `\n\nSystem prompt: ${project.systemPrompt}` : ''}`}
+              >
+                <div className="truncate font-medium">{project.name}</div>
+                {project.systemPrompt && (
+                  <div className="text-xs opacity-60 truncate">
+                    {project.systemPrompt}
+                  </div>
+                )}
+              </button>
+              
+              {/* Action buttons */}
+              <div className="flex gap-1 shrink-0">
+                <button
+                  aria-label="Edit project"
+                  title="Edit project"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleEdit(project);
+                  }}
+                  className="h-7 w-7 inline-flex items-center justify-center rounded-md border border-white/10 bg-white/5 hover:bg-blue-500/20 hover:border-blue-300/30 text-zinc-300 hover:text-blue-100 opacity-0 group-hover:opacity-100 transition-opacity"
+                >
+                  <Settings size={12} />
+                </button>
+                <button
+                  aria-label="Delete project"
+                  title="Delete project"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete(project.id);
+                  }}
+                  className="h-7 w-7 inline-flex items-center justify-center rounded-md border border-white/10 bg-white/5 hover:bg-rose-500/20 hover:border-rose-300/30 text-zinc-300 hover:text-rose-100 opacity-0 group-hover:opacity-100 transition-opacity"
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <ProjectModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSave={handleSave}
+        project={editingProject}
+      />
+
+      <ConfirmDialog
+        open={!!confirmDeleteId}
+        title="Delete project?"
+        message="This will permanently delete the project and cannot be undone."
+        confirmText="Delete"
+        cancelText="Cancel"
+        onCancel={() => setConfirmDeleteId(null)}
+        onConfirm={confirmDelete}
+      />
+    </>
+  );
+}

--- a/components/ThreadSidebar.tsx
+++ b/components/ThreadSidebar.tsx
@@ -2,7 +2,9 @@
 import { useState } from "react";
 import { ChevronLeft, ChevronRight, Plus, X, Trash2 } from "lucide-react";
 import type { ChatThread } from "@/lib/types";
+import type { Project } from "@/lib/projects";
 import ConfirmDialog from "@/components/ConfirmDialog";
+import ProjectsSection from "@/components/ProjectsSection";
 
 type Props = {
   sidebarOpen: boolean;
@@ -15,6 +17,13 @@ type Props = {
   onCloseMobile: () => void;
   onOpenMobile: () => void;
   onDeleteThread: (id: string) => void;
+  // Projects props
+  projects: Project[];
+  activeProjectId: string | null;
+  onSelectProject: (id: string | null) => void;
+  onCreateProject: (project: Project) => void;
+  onUpdateProject: (project: Project) => void;
+  onDeleteProject: (id: string) => void;
 };
 
 export default function ThreadSidebar({
@@ -27,6 +36,12 @@ export default function ThreadSidebar({
   mobileSidebarOpen,
   onCloseMobile,
   onDeleteThread,
+  projects,
+  activeProjectId,
+  onSelectProject,
+  onCreateProject,
+  onUpdateProject,
+  onDeleteProject,
 }: Props) {
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   return (
@@ -59,6 +74,19 @@ export default function ThreadSidebar({
 
         {sidebarOpen ? (
           <>
+            {/* Projects Section */}
+            <div className="mb-4">
+              <ProjectsSection
+                projects={projects}
+                activeProjectId={activeProjectId}
+                onSelectProject={onSelectProject}
+                onCreateProject={onCreateProject}
+                onUpdateProject={onUpdateProject}
+                onDeleteProject={onDeleteProject}
+                collapsed={false}
+              />
+            </div>
+
             <button
               onClick={onNewChat}
               className="mb-3 text-sm px-3 py-2 rounded-md text-white shadow transition-colors accent-action-fill accent-focus"
@@ -105,6 +133,19 @@ export default function ThreadSidebar({
           </>
         ) : (
           <div className="flex-1 flex flex-col items-center pt-6">
+            {/* Projects Section (Collapsed) */}
+            <div className="mb-4 w-full">
+              <ProjectsSection
+                projects={projects}
+                activeProjectId={activeProjectId}
+                onSelectProject={onSelectProject}
+                onCreateProject={onCreateProject}
+                onUpdateProject={onUpdateProject}
+                onDeleteProject={onDeleteProject}
+                collapsed={true}
+              />
+            </div>
+
             {/* New chat button */}
             <button
               title="New Chat"
@@ -164,6 +205,23 @@ export default function ThreadSidebar({
                 <X size={16} />
               </button>
             </div>
+
+            {/* Projects Section (Mobile) */}
+            <div className="mb-4">
+              <ProjectsSection
+                projects={projects}
+                activeProjectId={activeProjectId}
+                onSelectProject={(id) => {
+                  onSelectProject(id);
+                  // Don't close mobile sidebar for project selection
+                }}
+                onCreateProject={onCreateProject}
+                onUpdateProject={onUpdateProject}
+                onDeleteProject={onDeleteProject}
+                collapsed={false}
+              />
+            </div>
+
             <button
               onClick={() => {
                 onNewChat();

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,0 +1,67 @@
+export interface Project {
+  id: string;
+  name: string;
+  systemPrompt: string;
+  createdAt: number;
+  updatedAt: number;
+  isActive?: boolean;
+}
+
+export const DEFAULT_PROJECT: Omit<Project, 'id' | 'createdAt' | 'updatedAt'> = {
+  name: '',
+  systemPrompt: '',
+  isActive: false,
+};
+
+// Generate UUID for projects
+export function generateProjectId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  // Fallback UUID v4 generator
+  return 'proj-xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+export function createProject(
+  name: string, 
+  systemPrompt: string = ''
+): Project {
+  const now = Date.now();
+  return {
+    id: generateProjectId(),
+    name: name.trim() || 'Untitled Project',
+    systemPrompt: systemPrompt.trim(),
+    createdAt: now,
+    updatedAt: now,
+    isActive: false,
+  };
+}
+
+export function updateProject(
+  project: Project, 
+  updates: Partial<Pick<Project, 'name' | 'systemPrompt' | 'isActive'>>
+): Project {
+  return {
+    ...project,
+    ...updates,
+    name: updates.name?.trim() || project.name,
+    systemPrompt: updates.systemPrompt?.trim() ?? project.systemPrompt,
+    updatedAt: Date.now(),
+  };
+}
+
+export function validateProjectName(name: string): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) return 'Project name is required';
+  if (trimmed.length > 50) return 'Project name must be 50 characters or less';
+  return null;
+}
+
+export function validateSystemPrompt(prompt: string): string | null {
+  if (prompt.length > 1000) return 'System prompt must be 1000 characters or less';
+  return null;
+}

--- a/lib/useProjects.ts
+++ b/lib/useProjects.ts
@@ -1,0 +1,102 @@
+"use client";
+import { useState, useEffect } from 'react';
+import { Project } from '@/lib/projects';
+
+const STORAGE_KEY = 'ai-fiesta:projects';
+const ACTIVE_PROJECT_KEY = 'ai-fiesta:active-project';
+
+export function useProjects() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load projects from localStorage on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      const activeId = localStorage.getItem(ACTIVE_PROJECT_KEY);
+      
+      if (saved) {
+        const parsed = JSON.parse(saved) as Project[];
+        setProjects(Array.isArray(parsed) ? parsed : []);
+      }
+      
+      if (activeId && activeId !== 'null') {
+        setActiveProjectId(activeId);
+      }
+    } catch (error) {
+      console.warn('Failed to load projects from localStorage:', error);
+    } finally {
+      setIsLoaded(true);
+    }
+  }, []);
+
+  // Save projects to localStorage whenever they change
+  useEffect(() => {
+    if (isLoaded) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(projects));
+      } catch (error) {
+        console.warn('Failed to save projects to localStorage:', error);
+      }
+    }
+  }, [projects, isLoaded]);
+
+  // Save active project ID to localStorage whenever it changes
+  useEffect(() => {
+    if (isLoaded) {
+      try {
+        if (activeProjectId) {
+          localStorage.setItem(ACTIVE_PROJECT_KEY, activeProjectId);
+        } else {
+          localStorage.removeItem(ACTIVE_PROJECT_KEY);
+        }
+      } catch (error) {
+        console.warn('Failed to save active project to localStorage:', error);
+      }
+    }
+  }, [activeProjectId, isLoaded]);
+
+  const createProject = (project: Project) => {
+    setProjects(prev => [project, ...prev]);
+  };
+
+  const updateProject = (updatedProject: Project) => {
+    setProjects(prev => 
+      prev.map(p => p.id === updatedProject.id ? updatedProject : p)
+    );
+  };
+
+  const deleteProject = (id: string) => {
+    setProjects(prev => prev.filter(p => p.id !== id));
+    // If deleting the active project, clear active selection
+    if (activeProjectId === id) {
+      setActiveProjectId(null);
+    }
+  };
+
+  const selectProject = (id: string | null) => {
+    setActiveProjectId(id);
+  };
+
+  const getActiveProject = (): Project | null => {
+    if (!activeProjectId) return null;
+    return projects.find(p => p.id === activeProjectId) || null;
+  };
+
+  const getProjectById = (id: string): Project | null => {
+    return projects.find(p => p.id === id) || null;
+  };
+
+  return {
+    projects,
+    activeProjectId,
+    activeProject: getActiveProject(),
+    isLoaded,
+    createProject,
+    updateProject,
+    deleteProject,
+    selectProject,
+    getProjectById,
+  };
+}


### PR DESCRIPTION
## Features

- Add Projects section to sidebar with create/edit/delete functionality
- Implement project modal with name and system prompt fields (max 50/1000 chars)
- Add project selection with visual active state indication
- Integrate system prompt injection for all AI models 
- Support responsive design for desktop/mobile with collapsed sidebar mode
- Add persistent localStorage storage for projects and active selection
- Include form validation, confirmation dialogs, and theme integration

Components: ProjectsSection, ProjectModal, useProjects hook, project utilities
Modified: ThreadSidebar, chatActions, page layout for full integration

`npm run lint` and `npm run build` tested and passed!

### Issue resolved #19 


## Visuals

<img width="504" height="1170" alt="image" src="https://github.com/user-attachments/assets/e98940cb-1e87-4512-895f-822ecf4ef90f" />

You can navigate between chats as well as projects and can also choose to not be in any project. 

<img width="892" height="1088" alt="image" src="https://github.com/user-attachments/assets/5179f69a-d86a-4fc3-b453-eaa305f196ae" />
