### PR TITLE
Add abort controller functionality to manage ongoing requests in chat…

### DIFF
--- a/lib/chatActions.ts
+++ b/lib/chatActions.ts
@@ -4,6 +4,21 @@ import type { AiModel, ApiKeys, ChatMessage, ChatThread } from './types';
 import type { Project } from './projects';
 import { toast } from "react-toastify";
 
+const abortControllers: Record<string, AbortController> = {};
+
+function abortAll() {
+  Object.values(abortControllers).forEach(controller => {
+    try {
+      controller.abort();
+    } catch (e) {
+      // ignore
+    }
+  });
+  for (const key in abortControllers) {
+    delete abortControllers[key];
+  }
+}
+
 export type ChatDeps = {
   selectedModels: AiModel[];
   keys: ApiKeys;
@@ -71,14 +86,16 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
     const prompt = text.trim();
     if (!prompt) return;
 
-  if (selectedModels.length === 0) { 
-  toast.warn("Select at least one model.", {
-    style: {
-    background: "#ff4d4f",
-    color: "#fff",
-          },
-         }); 
-     }
+    abortAll();
+
+    if (selectedModels.length === 0) { 
+      toast.warn("Select at least one model.", {
+        style: {
+          background: "#ff4d4f",
+          color: "#fff",
+        },
+      }); 
+    }
     
     const userMsg: ChatMessage = { role: 'user', content: prompt, ts: Date.now() };
     const thread = ensureThread();
@@ -87,6 +104,8 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
 
     setLoadingIdsInit(selectedModels.map(m => m.id));
     await Promise.allSettled(selectedModels.map(async (m) => {
+      const controller = new AbortController();
+      abortControllers[m.id] = controller;
       try {
         if (m.provider === 'gemini') {
           // create placeholder for typing animation
@@ -94,7 +113,7 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
           const placeholder: ChatMessage = { role: 'assistant', content: '', modelId: m.id, ts: placeholderTs };
           setThreads(prev => prev.map(t => t.id === thread.id ? { ...t, messages: [...(t.messages ?? nextHistory), placeholder] } : t));
 
-          const res = await callGemini({ apiKey: keys.gemini || undefined, model: m.model, messages: prepareMessages(nextHistory), imageDataUrl });
+          const res = await callGemini({ apiKey: keys.gemini || undefined, model: m.model, messages: prepareMessages(nextHistory), imageDataUrl, signal: controller.signal });
           const full = String(extractText(res) || '').trim();
           if (!full) {
             setThreads(prev => prev.map(t => {
@@ -146,7 +165,7 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
           const isNonImageAttachment = !!imageDataUrl && (!mt || !isImage); // txt/pdf/docx or unknown
 
           if (isNonImageAttachment) {
-            const res = await callOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: prepareMessages(nextHistory), imageDataUrl });
+            const res = await callOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: prepareMessages(nextHistory), imageDataUrl, signal: controller.signal });
             const text = extractText(res);
             setThreads(prev => prev.map(t => {
               if (t.id !== thread.id) return t;
@@ -156,7 +175,7 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
             return;
           }
 
-          await streamOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: prepareMessages(nextHistory), imageDataUrl }, {
+          await streamOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: prepareMessages(nextHistory), imageDataUrl, signal: controller.signal }, {
             onToken: (delta) => {
               gotAny = true;
               buffer += delta;
@@ -183,7 +202,7 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
               flush();
               if (!gotAny) {
                 try {
-                  const res = await callOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: nextHistory, imageDataUrl });
+                  const res = await callOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: nextHistory, imageDataUrl, signal: controller.signal });
                   const text = extractText(res);
                   setThreads(prev => prev.map(t => {
                     if (t.id !== thread.id) return t;
@@ -196,6 +215,7 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
           });
         }
       } finally {
+        delete abortControllers[m.id];
         setLoadingIds(prev => prev.filter(x => x !== m.id));
       }
     }));
@@ -206,6 +226,8 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
     const t = threads.find(tt => tt.id === activeThread.id);
     if (!t) return;
     const original = [...(t.messages ?? [])];
+
+    abortAll();
 
     let userCount = -1;
     let userIdx = -1;
@@ -241,12 +263,14 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
 
     setLoadingIdsInit(selectedModels.map(m => m.id));
     Promise.allSettled(selectedModels.map(async (m) => {
+      const controller = new AbortController();
+      abortControllers[m.id] = controller;
       const ph = placeholders.find(p => p.model.id === m.id);
       if (!ph) { setLoadingIds(prev => prev.filter(x => x !== m.id)); return; }
       const placeholderTs = ph.ts;
       try {
         if (m.provider === 'gemini') {
-          const res = await callGemini({ apiKey: keys.gemini || undefined, model: m.model, messages: baseHistory });
+          const res = await callGemini({ apiKey: keys.gemini || undefined, model: m.model, messages: baseHistory, signal: controller.signal });
           const full = String(extractText(res) || '').trim();
           if (!full) {
             setThreads(prev => prev.map(tt => {
@@ -287,7 +311,7 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
               return { ...tt, messages: msgs };
             }));
           };
-          await streamOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: baseHistory }, {
+          await streamOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: baseHistory, signal: controller.signal }, {
             onToken: (delta) => {
               gotAny = true;
               buffer += delta;
@@ -314,7 +338,7 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
               flush();
               if (!gotAny) {
                 try {
-                  const res = await callOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: baseHistory });
+                  const res = await callOpenRouter({ apiKey: keys.openrouter || undefined, model: m.model, messages: baseHistory, signal: controller.signal });
                   const text = extractText(res);
                   setThreads(prev => prev.map(tt => {
                     if (tt.id !== t.id) return tt;
@@ -327,6 +351,7 @@ export function createChatActions({ selectedModels, keys, threads, activeThread,
           });
         }
       } finally {
+        delete abortControllers[m.id];
         setLoadingIds(prev => prev.filter(x => x !== m.id));
       }
     }));

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,20 +1,22 @@
 import { ChatMessage } from './types';
 
-export async function callGemini(args: { apiKey?: string; model: string; messages: ChatMessage[]; imageDataUrl?: string }) {
+export async function callGemini(args: { apiKey?: string; model: string; messages: ChatMessage[]; imageDataUrl?: string, signal?: AbortSignal }) {
   const endpoint = args.model === 'gemini-2.5-pro' ? '/api/gemini-pro' : '/api/gemini';
   const res = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(args),
+    signal: args.signal,
   });
   return res.json();
 }
 
-export async function callOpenRouter(args: { apiKey?: string; model: string; messages: ChatMessage[]; imageDataUrl?: string }) {
+export async function callOpenRouter(args: { apiKey?: string; model: string; messages: ChatMessage[]; imageDataUrl?: string, signal?: AbortSignal }) {
   const res = await fetch('/api/openrouter', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ...args, referer: typeof window !== 'undefined' ? window.location.origin : undefined, title: 'AI Fiesta' }),
+    signal: args.signal,
   });
   return res.json();
 }
@@ -26,24 +28,28 @@ export type ORStreamHandlers = {
   onDone?: () => void;
 };
 
-export async function streamOpenRouter(args: { apiKey?: string; model: string; messages: ChatMessage[]; imageDataUrl?: string }, handlers: ORStreamHandlers) {
-  const res = await fetch('/api/openrouter/stream', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...args, referer: typeof window !== 'undefined' ? window.location.origin : undefined, title: 'AI Fiesta' }),
-  });
-  if (!res.body) {
-    handlers.onError?.({ error: 'No stream body', code: res.status, provider: 'openrouter' });
-    handlers.onDone?.();
-    return;
-  }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const pump = async (): Promise<void> => {
-    try {
+export async function streamOpenRouter(args: { apiKey?: string; model: string; messages: ChatMessage[]; imageDataUrl?: string, signal?: AbortSignal }, handlers: ORStreamHandlers) {
+  try {
+    const res = await fetch('/api/openrouter/stream', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...args, referer: typeof window !== 'undefined' ? window.location.origin : undefined, title: 'AI Fiesta' }),
+      signal: args.signal,
+    });
+    if (!res.body) {
+      handlers.onError?.({ error: 'No stream body', code: res.status, provider: 'openrouter' });
+      handlers.onDone?.();
+      return;
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    const pump = async (): Promise<void> => {
       const { value, done } = await reader.read();
-      if (done) { handlers.onDone?.(); return; }
+      if (done) {
+        handlers.onDone?.();
+        return;
+      }
       buffer += decoder.decode(value, { stream: true });
       const parts = buffer.split('\n\n');
       buffer = parts.pop() || '';
@@ -51,7 +57,10 @@ export async function streamOpenRouter(args: { apiKey?: string; model: string; m
         const line = part.trim();
         if (!line.startsWith('data:')) continue;
         const payload = line.slice(5).trim();
-        if (payload === '[DONE]') { handlers.onDone?.(); return; }
+        if (payload === '[DONE]') {
+          handlers.onDone?.();
+          return;
+        }
         try {
           const json = JSON.parse(payload);
           if (typeof json?.delta === 'string' && json.delta) handlers.onToken(json.delta);
@@ -62,16 +71,14 @@ export async function streamOpenRouter(args: { apiKey?: string; model: string; m
         }
       }
       return pump();
-    } catch (err) {
-      const e = err as Error | undefined;
-      handlers.onError?.({ error: e?.message || 'Stream failed', provider: 'openrouter' });
+    };
+    await pump();
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      // Abort is expected, no need to show an error.
       handlers.onDone?.();
       return;
     }
-  };
-  try {
-    await pump();
-  } catch (err) {
     const e = err as Error | undefined;
     handlers.onError?.({ error: e?.message || 'Stream failed', provider: 'openrouter' });
     handlers.onDone?.();


### PR DESCRIPTION
The recent changes address a critical issue where multiple, overlapping AI requests could occur, leading to wasted resources and a confusing user experience.

Previously, if you sent a new message or edited a prompt while a response was still being generated, the original request would continue running in the background. This often resulted in duplicate or out-of-sync replies, UI flickering, and unnecessary token consumption.

To fix this, I've implemented a request cancellation mechanism. Now, whenever a new request is initiated, any pending requests from the previous interaction are automatically aborted. This ensures that only the most recent prompt is being processed, making the chat interface more predictable, efficient, and cost-effective.

Fixes #23 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now cancel in-flight AI responses, including streaming, image, and attachment flows. Cancellation applies per model and takes effect immediately.
- Bug Fixes
  - Editing a message stops any ongoing operations first, preventing duplicate or lingering requests.
  - Streaming is more resilient: aborts no longer surface as errors, and completion is handled consistently.
  - Improved reliability and cleanup after requests, reducing stuck spinners and timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->