### PR TITLE
Refactor Ollama API for multiple models and timeout management

### DIFF
--- a/app/api/ollama/route.ts
+++ b/app/api/ollama/route.ts
@@ -3,96 +3,100 @@ import { NextRequest } from 'next/server';
 export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
-  let timeoutId: NodeJS.Timeout | null = null;
-
   try {
-    const { messages, model, baseUrl } = await req.json();
+    const { messages, model, baseUrl, models } = await req.json();
     // For Ollama, we get the base URL from the request body (user settings) or environment or default to localhost
     const ollamaUrl = baseUrl || process.env.OLLAMA_URL || 'http://localhost:11434';
 
     if (process.env.DEBUG_OLLAMA === '1') console.log(`Calling Ollama model: ${model} at ${ollamaUrl}`);
 
-    // Convert messages to Ollama format
-    const ollamaMessages = messages.map((msg: { role: string; content: string }) => ({
-      role: msg.role,
-      content: msg.content
-    }));
+    // Support both single model and array of models
+    const modelList = Array.isArray(models) ? models : model ? [model] : [];
 
-    const requestBody = {
-      model: model,
-      messages: ollamaMessages,
-      stream: false
-    };
-
-    if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama request body:`, JSON.stringify(requestBody, null, 2));
-
-    const controller = new AbortController();
-    timeoutId = setTimeout(() => {
-      if (process.env.DEBUG_OLLAMA === '1') console.log('Ollama request timeout triggered');
-      controller.abort();
-    }, 180000); // 180 second timeout (3 minutes)
-
-    const response = await fetch(`${ollamaUrl}/api/chat`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(requestBody),
-      signal: controller.signal,
-    });
-
-    if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama response status: ${response.status}`);
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama error response:`, errorText);
-      return new Response(JSON.stringify({
-        error: `Ollama API error: ${response.status} ${response.statusText}`,
-        details: errorText,
-        provider: 'ollama',
-        code: response.status
-      }), { status: 502 });
+    if (modelList.length === 0) {
+      // Fallback to single model if models array not provided
+      modelList.push(model);
     }
 
-    const data = await response.json();
-    if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama response data:`, JSON.stringify(data, null, 2));
+    // For each model, create a separate request with its own timeout/controller
+    const results = await Promise.allSettled(
+      modelList.map(async (mdl: string) => {
+        const ollamaMessages = messages.map((msg: { role: string; content: string }) => ({
+          role: msg.role,
+          content: msg.content
+        }));
 
-    // Extract the response text
-    let text = '';
-    if (data.message && data.message.content) {
-      text = data.message.content;
-    } else if (data.response) {
-      text = data.response;
-    } else {
-      text = 'No response from Ollama';
-    }
+        const requestBody = {
+          model: mdl,
+          messages: ollamaMessages,
+          stream: false
+        };
 
-    // Model list handling
-    let modelList: Array<{ name: string }> = [];
-    if (Array.isArray(data)) {
-      modelList = data as Array<{ name: string }>;
-    } else if (data && typeof data === 'object') {
-      // Check for models array in different possible locations
-      if (Array.isArray((data as { models?: Array<{ name: string }> }).models)) {
-        modelList = (data as { models: Array<{ name: string }> }).models;
-      } else if (Array.isArray((data as { data?: Array<{ name: string }> }).data)) {
-        modelList = (data as { data: Array<{ name: string }> }).data;
-      }
-    }
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => {
+          if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama request timeout triggered for model ${mdl}`);
+          controller.abort();
+        }, 180000); // 3 minutes per request
 
-    // Find the model
-    const slug = model.toLowerCase();
-    const found = modelList.find((m: { name: string }) => m && typeof m.name === 'string' && m.name === slug);
+        try {
+          const response = await fetch(`${ollamaUrl}/api/chat`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(requestBody),
+            signal: controller.signal,
+          });
 
-    // If model not found, provide a list of available models (up to 10)
-    if (!found && modelList.length > 0) {
-      (response as { availableModels?: string[] }).availableModels = modelList
-        .map((m: { name: string }) => m.name)
-        .filter((name: string): name is string => typeof name === 'string')
-        .slice(0, 10);
-    }
+          if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama response status for ${mdl}: ${response.status}`);
 
-    return Response.json({ text, raw: data });
+          if (!response.ok) {
+            const errorText = await response.text();
+            if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama error response for ${mdl}:`, errorText);
+            return {
+              model: mdl,
+              error: `Ollama API error: ${response.status} ${response.statusText}`,
+              details: errorText,
+              provider: 'ollama',
+              code: response.status
+            };
+          }
+
+          const data = await response.json();
+          if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama response data for ${mdl}:`, JSON.stringify(data, null, 2));
+
+          // Extract the response text
+          let text = '';
+          if (data.message && data.message.content) {
+            text = data.message.content;
+          } else if (data.response) {
+            text = data.response;
+          } else {
+            text = 'No response from Ollama';
+          }
+
+          return { model: mdl, text, raw: data };
+        } catch (e: unknown) {
+          const err = e as Error;
+          if (err?.name === 'AbortError') {
+            if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama request timed out for ${mdl}`);
+            return { model: mdl, error: 'Ollama request timed out', provider: 'ollama', code: 504 };
+          }
+          const message = err?.message || 'Unknown error';
+          if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama error for ${mdl}:`, message);
+          return { model: mdl, error: message, provider: 'ollama' };
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      })
+    );
+
+    // Format results: if only one model, return as before; else, return array
+    const formatted = modelList.length === 1
+      ? results[0].status === 'fulfilled' ? results[0].value : { error: 'Failed', ...results[0].reason }
+      : results.map(r => r.status === 'fulfilled' ? r.value : { error: 'Failed', ...r.reason });
+
+    return Response.json(formatted);
   } catch (e: unknown) {
     const err = e as Error;
     if (err?.name === 'AbortError') {
@@ -102,10 +106,5 @@ export async function POST(req: NextRequest) {
     const message = err?.message || 'Unknown error';
     if (process.env.DEBUG_OLLAMA === '1') console.log(`Ollama error:`, message);
     return new Response(JSON.stringify({ error: message, provider: 'ollama' }), { status: 500 });
-  } finally {
-    // Always clear the timeout
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
   }
 }

--- a/components/modals/ModelsModal.tsx
+++ b/components/modals/ModelsModal.tsx
@@ -4,6 +4,7 @@ import { X, Star, StarOff } from 'lucide-react';
 import type { AiModel } from '@/lib/types';
 import { MODEL_CATALOG } from '@/lib/models';
 import { useLocalStorage } from '@/lib/useLocalStorage';
+import { mergeModels } from '@/lib/customModels';
 
 export type ModelsModalProps = {
   open: boolean;
@@ -333,6 +334,9 @@ export default function ModelsModal({
     <Section key="Custom models" title="Custom models" models={customModels} showBadges={false} />
   );
 
+  // Use merged models for tab counts
+  const allModels = mergeModels(customModels);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
@@ -360,14 +364,14 @@ export default function ModelsModal({
         {/* Provider Filter Tabs */}
         <div className="flex flex-wrap gap-2 mb-4 pb-3 border-b border-white/10">
           {[
-            { id: 'all', label: 'All Models', count: MODEL_CATALOG.length },
-            { id: 'pro', label: 'Pro Models', count: MODEL_CATALOG.filter(m => m.provider === 'unstable' || m.provider === 'mistral').length },
-            { id: 'gemini', label: 'Gemini', count: MODEL_CATALOG.filter(m => m.provider === 'gemini').length },
-            { id: 'openrouter', label: 'OpenRouter', count: MODEL_CATALOG.filter(m => m.provider === 'openrouter').length },
-            { id: 'open-provider', label: 'Open Provider', count: MODEL_CATALOG.filter(m => m.provider === 'open-provider').length },
-            { id: 'unstable', label: 'Unstable', count: MODEL_CATALOG.filter(m => m.provider === 'unstable').length },
-            { id: 'mistral', label: 'Mistral', count: MODEL_CATALOG.filter(m => m.provider === 'mistral').length },
-            { id: 'ollama', label: 'Ollama', count: MODEL_CATALOG.filter(m => m.provider === 'ollama').length },
+            { id: 'all', label: 'All Models', count: allModels.length },
+            { id: 'pro', label: 'Pro Models', count: allModels.filter(m => m.provider === 'unstable' || m.provider === 'mistral').length },
+            { id: 'gemini', label: 'Gemini', count: allModels.filter(m => m.provider === 'gemini').length },
+            { id: 'openrouter', label: 'OpenRouter', count: allModels.filter(m => m.provider === 'openrouter').length },
+            { id: 'open-provider', label: 'Open Provider', count: allModels.filter(m => m.provider === 'open-provider').length },
+            { id: 'unstable', label: 'Unstable', count: allModels.filter(m => m.provider === 'unstable').length },
+            { id: 'mistral', label: 'Mistral', count: allModels.filter(m => m.provider === 'mistral').length },
+            { id: 'ollama', label: 'Ollama', count: allModels.filter(m => m.provider === 'ollama').length },
           ].map(provider => (
             <button
               key={provider.id}


### PR DESCRIPTION
1. Enhance the Ollama API request handling to support multiple models and improve timeout management. 
2. Update the ModelsModal to utilize merged models for accurate tab counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Support querying multiple models at once with independent timeouts and error handling.
  * Returns per-model results; single model returns one result, multiple models return an array.
* Breaking Changes
  * API response format updated to include model identifiers per result; previous flat response replaced by per-model result(s).
* UI Improvements
  * Model selector tab counts now include merged custom models across providers, improving accuracy of counts for “All” and provider tabs.
* Reliability
  * Improved handling of per-model timeouts and non-OK responses without failing the entire request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->