### PR TITLE
fix(docs): correct env file copy command (use env.example instead of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm i
    Copy the example environment file:
 
 ```bash
-cp .env.example .env
+cp env.example .env
 ```
 
 Then set the environment variables you plan to use. You can also enter keys at runtime in the app's Settings.


### PR DESCRIPTION
….env.example)

# Fix: Use Correct `env.example` File for `.env` Setup

## Description
This PR fixes the environment file copy command.  
Previously, the setup instructions referenced `.env.example`, but the actual file name is `env.example`.  
This caused `cp` to fail when running the setup instructions.

## SS:
<img width="761" height="155" alt="Screenshot 2025-09-11 125632" src="https://github.com/user-attachments/assets/f14729d5-f3bf-48ad-946b-7e9507a0c7a7" />

## Changes
- Updated copy command to use `env.example` as the source in readme file    

## Why
Without this fix, developers cannot create their `.env` file from the provided example, blocking local setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Quick Start environment setup instructions to use the proper example file and command syntax.
  * Improves clarity for new users during initial configuration and reduces setup friction.
  * Aligns the guide with the current repository structure.
  * No changes to application behavior; this update is purely informational to enhance onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->